### PR TITLE
Use Non-Default Service Account Bug Fix

### DIFF
--- a/python-clusters/dataproc-create-cluster/cluster.py
+++ b/python-clusters/dataproc-create-cluster/cluster.py
@@ -22,7 +22,7 @@ class MyCluster(Cluster):
         if not self.client:
             self.client = DataProcClient(self.config.get("gcloudProjectId")
                 ,asumeDefaultCredentials=self.config.get("gcloudUseDefaultSvcAccount")
-                ,service_account_details=self.config.get("gcloudGoogleServiceAccountKey")
+                ,service_account_details=json.loads(self.config.get("gcloudGoogleServiceAccountKey"))
                 )
 
         self.client.region = self.config.get("gcloudRegionId")

--- a/python-lib/gce_client.py
+++ b/python-lib/gce_client.py
@@ -1,6 +1,7 @@
 import os,sys
 import googleapiclient.discovery
 from google.auth import compute_engine
+from google.oauth2 import service_account
 import random
 import logging
 import time

--- a/python-lib/gce_client.py
+++ b/python-lib/gce_client.py
@@ -71,6 +71,8 @@ class DataProcClient(AbstractGCloudClient):
     def __init__ (self,project,asumeDefaultCredentials=False,service_account_details=None,service_account_file=None):
         self.apiVersion = "v1"
         self.projectId = project
+        self.assumeDefaultCredentials = asumeDefaultCredentials
+        self.service_account_details = service_account_details
 
         # client 
         if asumeDefaultCredentials:
@@ -301,7 +303,7 @@ class DataProcClient(AbstractGCloudClient):
     def getDataprocClusterByName(self,name):
         return self.__lookup__(name)
     def forkComputeClient(self):
-        computeClient = GcloudComputeClient(asumeDefaultCredentials=True)
+        computeClient = GcloudComputeClient(asumeDefaultCredentials=self.assumeDefaultCredentials, service_account_details=self.service_account_details)
         computeClient.region = self.region
         computeClient.zone = self.zone
         computeClient.projectId = self.projectId


### PR DESCRIPTION
In testing the dataproc clusters plugin, I tried using a non-default service account and specified the service account JSON key. This led to errors and ultimately determined that there were two things missing:

1. Missing import from google.oauth2 import service_account
2. Passing in the JSON service account key as a parsed python dict

Once those issues were fixed, the plugin works as expected.