### PR TITLE
Remove typo when using Hive metastore.

### DIFF
--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -3,3 +3,4 @@ google-auth
 google-cloud
 google-api-python-client
 googleapis-common-protos
+oauth2client

--- a/python-clusters/dataproc-create-cluster/cluster.py
+++ b/python-clusters/dataproc-create-cluster/cluster.py
@@ -78,7 +78,7 @@ class MyCluster(Cluster):
                 "javax.jdo.option.ConnectionUserName": self.config["metastoreJDBCUser"],
                 "javax.jdo.option.ConnectionPassword": self.config["metastoreJDBCPassword"],
             }
-            logging.imfo(" setting hive metastore for custom JDBC")
+            logging.info(" setting hive metastore for custom JDBC")
             self.client.setHiveConfToClusterDef(clusterBody,props)
         elif self.config["metastoreDBMode"] == "MYSQL":
             props = {
@@ -87,7 +87,7 @@ class MyCluster(Cluster):
                 "javax.jdo.option.ConnectionUserName": self.config["metastoreMySQLUser"],
                 "javax.jdo.option.ConnectionPassword": self.config["metastoreMySQLPassword"]
             }
-            logging.imfo(" setting hive metastore for MySQL")
+            logging.info(" setting hive metastore for MySQL")
             self.client.setHiveConfToClusterDef(clusterBody,props)
         elif self.config["metastoreDBMode"] == "GCLOUD_SQL":
             self.client.setHiveMetastoreToGoogleSql(clusterBody,instanceName,projectId=None,region=None,extraProps={})


### PR DESCRIPTION
There is a typo on [line 81](https://github.com/dataiku/dss-plugin-dataproc-clusters/blob/master/python-clusters/dataproc-create-cluster/cluster.py#L81)
and [line 90](https://github.com/dataiku/dss-plugin-dataproc-clusters/blob/master/python-clusters/dataproc-create-cluster/cluster.py#L90).

Instead of using `logging.imfo()` we should use `logging.info()`.